### PR TITLE
Add conversion functions to time types ( using `chrono` )

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +56,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -70,6 +85,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +111,19 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "core-foundation"
@@ -194,11 +228,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "iec104"
 version = "0.2.0"
 dependencies = [
  "async-trait",
  "atomic_enum",
+ "chrono",
  "humantime-serde",
  "lazy_static",
  "serde",
@@ -228,6 +287,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -319,6 +388,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_threads"
@@ -465,6 +543,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -802,10 +886,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "windows-sys"
@@ -856,7 +1044,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1", features = ["signal"] }
 [features]
 chrono = ["dep:chrono"]
 
-default = []
+default = ["chrono"]
 
 [lints.rust]
 dead_code = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ chrono = { version = "0.4", optional = true }
 tokio = { version = "1", features = ["signal"] }
 
 [features]
-with-chrono = ["chrono"]
+chrono = ["dep:chrono"]
 
 default = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,15 @@ tracing = "0.1.41"
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
+chrono = { version = "0.4", optional = true }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["signal"] }
+
+[features]
+with-chrono = ["chrono"]
+
+default = []
 
 [lints.rust]
 dead_code = "warn"

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -45,8 +45,8 @@ impl Cp24Time2a {
 }
 
 #[cfg(feature = "chrono")]
-impl<Tz: chrono::TimeZone> From<chrono::DateTime<Tz>> for Cp24Time2a {
-	fn from(dt: chrono::DateTime<Tz>) -> Self {
+impl<Tz: chrono::TimeZone> From<&chrono::DateTime<Tz>> for Cp24Time2a {
+	fn from(dt: &chrono::DateTime<Tz>) -> Self {
 		use chrono::Timelike;
 
 		let mut ms = (dt.timestamp_subsec_millis() + dt.second() * 1000) as u16;
@@ -129,10 +129,10 @@ impl Cp16Time2a {
 	}
 }
 
-impl TryFrom<tokio::time::Duration> for Cp16Time2a {
+impl TryFrom<&tokio::time::Duration> for Cp16Time2a {
 	type Error=ParseTimeError;
 
-	fn try_from(duration: tokio::time::Duration) -> Result<Self, Self::Error> {
+	fn try_from(duration: &tokio::time::Duration) -> Result<Self, Self::Error> {
 		let ms = duration.as_millis();
 		if ms > 59999 {
 			return MillisecondsError.fail();
@@ -220,9 +220,9 @@ impl Cp56Time2a {
 }
 
 #[cfg(feature = "chrono")]
-impl<Tz: chrono::TimeZone> From<chrono::DateTime<Tz>> for Cp56Time2a {
+impl<Tz: chrono::TimeZone> From<&chrono::DateTime<Tz>> for Cp56Time2a {
 	/// Note: Daylight Saving Time ( DST ) is **NOT** considered!
-	fn from(dt: chrono::DateTime<Tz>) -> Self {
+	fn from(dt: &chrono::DateTime<Tz>) -> Self {
 		use chrono::{Datelike, Timelike};
 
 		let mut ms = (dt.timestamp_subsec_millis() + dt.second() * 1000) as u16;

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -1,3 +1,7 @@
+//! CPXXTime2a time types.
+//! 
+//! Note: conversions for Daylight Saving Time ( DST ) are **NOT** supported yet!
+
 use snafu::Snafu;
 use tracing::instrument;
 

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -123,19 +123,23 @@ impl Cp16Time2a {
 	pub fn to_bytes(self) -> [u8; 2] {
 		self.ms.to_le_bytes()
 	}
+}
 
-	#[instrument]
-	pub fn to_duration(&self) -> tokio::time::Duration {
-		tokio::time::Duration::from_millis(self.ms as u64)
-	}
+impl TryFrom<tokio::time::Duration> for Cp16Time2a {
+	type Error=ParseTimeError;
 
-	#[instrument]
-	pub fn from_duration(duration: &tokio::time::Duration) -> Result<Self, ParseTimeError> {
+	fn try_from(duration: tokio::time::Duration) -> Result<Self, Self::Error> {
 		let ms = duration.as_millis();
 		if ms > 59999 {
 			return MillisecondsError.fail();
 		}
 		Ok(Self { ms: ms as u16 })
+	}
+}
+
+impl Into<tokio::time::Duration> for Cp16Time2a {
+	fn into(self) -> tokio::time::Duration {
+		tokio::time::Duration::from_millis(self.ms as u64)
 	}
 }
 

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -39,7 +39,7 @@ impl Cp24Time2a {
 		bytes
 	}
 
-	#[cfg(feature = "with-chrono")]
+	#[cfg(feature = "chrono")]
 	#[instrument]
 	pub fn from_chrono<Tz: chrono::TimeZone>(dt: chrono::DateTime<Tz>) -> Self {
 		use chrono::Timelike;
@@ -54,7 +54,7 @@ impl Cp24Time2a {
 		return Self { ms, iv, min };
 	}
 
-	#[cfg(feature = "with-chrono")]
+	#[cfg(feature = "chrono")]
 	#[instrument]
 	pub fn to_chrono_local(&self) -> Result<chrono::DateTime<chrono::Local>, ParseTimeError> {
 		use chrono::Timelike;
@@ -71,7 +71,7 @@ impl Cp24Time2a {
 		return Ok(t);
 	}
 
-	#[cfg(feature = "with-chrono")]
+	#[cfg(feature = "chrono")]
 	#[instrument]
 	pub fn to_chrono_utc(&self) -> Result<chrono::DateTime<chrono::Utc>, ParseTimeError> {
 		use chrono::Timelike;
@@ -197,7 +197,7 @@ impl Cp56Time2a {
 		bytes
 	}
 
-	#[cfg(feature = "with-chrono")]
+	#[cfg(feature = "chrono")]
 	#[instrument]
 	pub fn from_chrono_ignoring_dst<Tz: chrono::TimeZone>(
 		dt: chrono::DateTime<Tz>,
@@ -220,7 +220,7 @@ impl Cp56Time2a {
 		return Ok(Self { ms, iv, min, summer_time, hour, weekday, day, month, year });
 	}
 
-	#[cfg(feature = "with-chrono")]
+	#[cfg(feature = "chrono")]
 	#[instrument]
 	pub fn to_chrono_local_ignoring_dst(
 		&self,
@@ -247,7 +247,7 @@ impl Cp56Time2a {
 		return Ok(t);
 	}
 
-	#[cfg(feature = "with-chrono")]
+	#[cfg(feature = "chrono")]
 	#[instrument]
 	pub fn to_chrono_utc(&self) -> Result<chrono::DateTime<chrono::Utc>, ParseTimeError> {
 		use chrono::{Datelike, Timelike};


### PR DESCRIPTION
It is not easy to work with `Cp**Time2a` structs ( e.g. calculating the duration between 2 `Cp56Time2a`s ).
This PR adds a feature called `with-chrono`, which is not enabled by default. If enabled, additional conversion functions between `chrono::DateTime` and `Cp42Time2a`/`Cp56Time2a` will be available.
Some implements of IEC60870-5 use UTC time zone while others use local time zone. The users should choose the right version of  conversion functions according to the other side.