### PR TITLE
Fix wrong APDU parsing when `sequence` = `true`

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -200,7 +200,7 @@ impl InformationObjects {
 					// have the object_size.
 					// Since the i starts at 0, we need to add 1 to the address.
 					let address = first_addr + (i as u32) + 1;
-					let object = T::from_bytes(&chunk[ADDRESS_SIZE..])?;
+					let object = T::from_bytes(chunk)?;
 					Ok(GenericObject { address, object })
 				})
 				.collect::<Result<Vec<_>, ParseError>>()?;


### PR DESCRIPTION
Currently, APDU parsing does not work when `sequence` = `true`.
A `Error receiving APDU` error will raise even if the telegram is OK.
Here is a case:
Server side: [test_server.py](https://github.com/user-attachments/files/23621559/test_server.py.txt)
Client side: [client.rs](https://github.com/user-attachments/files/23621579/client.rs.txt)
Log: [log.txt](https://github.com/user-attachments/files/23621591/log.txt)

This one-line patch will fix the bug.

Log after fix: [log_fixed.txt](https://github.com/user-attachments/files/23621608/log_fixed.txt)