### PR TITLE
Fix unsafe cancel issue on read

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         types: [rust]
         pass_filenames: false
   - repo: https://github.com/DevinR528/cargo-sort
-    rev: v1.1.0
+    rev: v2.0.2
     hooks:
       - id: cargo-sort
   - repo: https://github.com/crate-ci/typos

--- a/src/apdu.rs
+++ b/src/apdu.rs
@@ -6,7 +6,7 @@ use crate::{
 	error::{self, Error, InvalidAsdu, NotEnoughBytes, SizedSlice},
 };
 
-pub(crate) const TELEGRAN_HEADER: u8 = 0x68;
+pub(crate) const TELEGRAM_HEADER: u8 = 0x68;
 pub(crate) const APUD_MAX_LENGTH: u8 = 253;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -22,7 +22,7 @@ impl Apdu {
 		if data.len() < 6 {
 			return error::ApduTooShort.fail();
 		}
-		if data[0] != TELEGRAN_HEADER {
+		if data[0] != TELEGRAM_HEADER {
 			return error::InvalidTelegramHeader.fail();
 		}
 
@@ -46,7 +46,7 @@ impl Apdu {
 		// The total length of the APDU is the length of the frame plus 2 bytes, one for
 		// the header and one for the length
 		let mut bytes = Vec::with_capacity(self.length as usize + 2);
-		bytes.push(TELEGRAN_HEADER);
+		bytes.push(TELEGRAM_HEADER);
 		bytes.push(self.length);
 		self.frame.to_bytes(&mut bytes)?;
 		Ok(bytes)
@@ -82,7 +82,7 @@ impl Frame {
 	}
 	pub fn to_apdu_bytes(&self) -> Result<Vec<u8>, Error> {
 		let mut buffer = Vec::new();
-		buffer.push(TELEGRAN_HEADER);
+		buffer.push(TELEGRAM_HEADER);
 		buffer.push(0); // length placeholder
 		self.to_bytes(&mut buffer)?;
 		buffer[1] = (buffer.len() - 2) as u8; // update length

--- a/src/client/receive_handler.rs
+++ b/src/client/receive_handler.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use lazy_static::lazy_static;
-use snafu::{ResultExt as _, whatever};
+use snafu::{FromString, ResultExt as _, whatever};
 use tokio::{
 	io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _, ReadHalf, WriteHalf},
 	select,
@@ -112,31 +112,46 @@ impl<'a> ReceiveHandler<'a> {
 		Apdu::from_bytes(&buffer[0..length + 2]).whatever_context("Error decoding APDU")
 	}
 
-	fn parse_apdus(cache:&mut Vec<u8>)->Result<Vec<Apdu>, Error> {
+	fn parse_apdus(cache: &mut Vec<u8>) -> (Vec<Apdu>, Option<Error>) {
 		if cache.len() < 2 {
-			return Ok(Vec::new());
+			return (Vec::new(), None);
 		}
 		let mut apdus = Vec::new();
 		let mut next_start_i = 0;
 		let mut i = 0;
+		let mut err = None;
 		while i < cache.len() - 1 {
 			if cache[i] == TELEGRAM_HEADER {
 				let length = cache[i + 1] as usize;
 				if length > APUD_MAX_LENGTH as usize {
-					whatever!("Invalid length: {}", length);
+					err = Some(Error::without_source(format!("Invalid length: {length}")));
+					break;
 				}
 				if cache.len() < length + i + 2 {
 					break;
 				} else {
-					apdus.push(
-						Apdu::from_bytes(&cache[i..i + length + 2])
-							.whatever_context("Error decoding APDU")?,
-					);
-					i += length + 2;
-					next_start_i = i;
+					match Apdu::from_bytes(&cache[i..i + length + 2]) {
+						Ok(apdu) => {
+							apdus.push(apdu);
+							i += length + 2;
+							next_start_i = i;
+						}
+						Err(e) => {
+							err = Some(Error::with_source(
+								Box::new(e),
+								"Error decoding APDU".to_owned(),
+							));
+							break;
+						}
+					}
 				}
-			}else{
-				whatever!("Invalid starter byte: {:02x}{:02x}", cache[i], cache[i+1]);
+			} else {
+				err = Some(Error::without_source(format!(
+					"Invalid starter byte: {:02x}{:02x}",
+					cache[i],
+					cache[i + 1]
+				)));
+				break;
 			}
 		}
 		if next_start_i >= cache.len() {
@@ -144,7 +159,7 @@ impl<'a> ReceiveHandler<'a> {
 		} else if next_start_i > 0 {
 			*cache = cache.split_off(next_start_i);
 		}
-		Ok(apdus)
+		(apdus, err)
 	}
 
 	#[instrument(level = "debug", skip_all)]
@@ -162,7 +177,7 @@ impl<'a> ReceiveHandler<'a> {
 						whatever!("Connection closed");
 					}
 					cache.extend_from_slice(&buffer[0..len]);
-					let apdus = Self::parse_apdus(&mut cache)?;
+					let (apdus, err) = Self::parse_apdus(&mut cache);
 					if !apdus.is_empty() {
 						for apdu in apdus {
 							match apdu.frame {
@@ -186,6 +201,9 @@ impl<'a> ReceiveHandler<'a> {
 							}
 						}
 						self.t3.as_mut().reset(Instant::now() + self.config.protocol.t3);
+					}
+					if let Some(e) = err {
+						return Err(e);
 					}
 				}
 				Some(cmd) = self.rx.recv() => {

--- a/src/client/receive_handler.rs
+++ b/src/client/receive_handler.rs
@@ -112,38 +112,81 @@ impl<'a> ReceiveHandler<'a> {
 		Apdu::from_bytes(&buffer[0..length + 2]).whatever_context("Error decoding APDU")
 	}
 
+	fn parse_apdus(cache:&mut Vec<u8>)->Result<Vec<Apdu>, Error> {
+		if cache.len() < 2 {
+			return Ok(Vec::new());
+		}
+		let mut apdus = Vec::new();
+		let mut next_start_i = 0;
+		let mut i = 0;
+		while i < cache.len() - 1 {
+			if cache[i] == TELEGRAN_HEADER {
+				let length = cache[i + 1] as usize;
+				if length > APUD_MAX_LENGTH as usize {
+					whatever!("Invalid length: {}", length);
+				}
+				if cache.len() < length + i + 2 {
+					break;
+				} else {
+					apdus.push(
+						Apdu::from_bytes(&cache[i..i + length + 2])
+							.whatever_context("Error decoding APDU")?,
+					);
+					i += length + 2;
+					next_start_i = i;
+					continue;
+				}
+			}else{
+				whatever!("Invalid starter byte: {:02x}{:02x}", cache[i], cache[i+1]);
+			}
+		}
+		if next_start_i >= cache.len() {
+			cache.clear();
+		} else if next_start_i > 0 {
+			*cache = cache.split_off(next_start_i);
+		}
+		return Ok(apdus);
+	}
+
 	#[instrument(level = "debug", skip_all)]
 	pub async fn receive_task(mut self) -> Result<(), Error> {
 		self.t3.as_mut().reset(Instant::now() + self.config.protocol.t3);
 
+		let mut cache = Vec::new();
 		let mut buffer = [0; 255];
 
 		loop {
 			select! {
-				apdu = Self::receive_apdu(&mut self.read_connection,	&mut buffer) => {
-					if let Ok(apdu) = apdu {
-						match apdu.frame {
-							Frame::I(i) => {
-								self.handle_receive_i_frame(&i)?;
-								let new_t2_instant = Instant::now() + self.config.protocol.t2;
-								if new_t2_instant < self.t2.deadline() {
-									self.t2.as_mut().reset(new_t2_instant);
+				res = self.read_connection.read(&mut buffer)=>{
+					let len = res.whatever_context("Error receiving data")?;
+					if len == 0 {
+						whatever!("Connection closed");
+					}
+					cache.extend_from_slice(&buffer[0..len]);
+					let apdus = Self::parse_apdus(&mut cache)?;
+					if !apdus.is_empty() {
+						for apdu in apdus {
+							match apdu.frame {
+								Frame::I(i) => {
+									self.handle_receive_i_frame(&i)?;
+									let new_t2_instant = Instant::now() + self.config.protocol.t2;
+									if new_t2_instant < self.t2.deadline() {
+										self.t2.as_mut().reset(new_t2_instant);
+									}
+									self.callback.on_new_objects(i.asdu).await;
 								}
-								self.callback.on_new_objects(i.asdu).await;
-							}
-							Frame::S(s) => {
-								self.handle_receive_s_frame(&s)?;
-							}
-							Frame::U(u) => {
-								let should_stop = self.handle_receive_u_frame(&u).await?;
-								if should_stop {
-									return Ok(());
+								Frame::S(s) => {
+									self.handle_receive_s_frame(&s)?;
+								}
+								Frame::U(u) => {
+									let should_stop = self.handle_receive_u_frame(&u).await?;
+									if should_stop {
+										return Ok(());
+									}
 								}
 							}
 						}
 						self.t3.as_mut().reset(Instant::now() + self.config.protocol.t3);
-					} else {
-						whatever!("Error receiving APDU");
 					}
 				}
 				Some(cmd) = self.rx.recv() => {

--- a/src/client/receive_handler.rs
+++ b/src/client/receive_handler.rs
@@ -16,7 +16,7 @@ use tokio::{
 use tracing::instrument;
 
 use crate::{
-	apdu::{APUD_MAX_LENGTH, Apdu, Frame, IFrame, SFrame, TELEGRAN_HEADER, UFrame},
+	apdu::{APUD_MAX_LENGTH, Apdu, Frame, IFrame, SFrame, TELEGRAM_HEADER, UFrame},
 	asdu::Asdu,
 	client::{
 		Connection, OnNewObjects, START_DT_CON_FRAME, STOP_DT_ACT_FRAME, STOP_DT_CON_FRAME,
@@ -98,7 +98,7 @@ impl<'a> ReceiveHandler<'a> {
 		buffer: &mut [u8; 255],
 	) -> Result<Apdu, Error> {
 		connection.read(&mut buffer[0..2]).await.whatever_context("Error receiving data")?;
-		if buffer[0] != TELEGRAN_HEADER {
+		if buffer[0] != TELEGRAM_HEADER {
 			whatever!("Invalid starter byte: {:02x}{:02x}", buffer[0], buffer[1]);
 		}
 		let length = buffer[1] as usize;
@@ -120,7 +120,7 @@ impl<'a> ReceiveHandler<'a> {
 		let mut next_start_i = 0;
 		let mut i = 0;
 		while i < cache.len() - 1 {
-			if cache[i] == TELEGRAN_HEADER {
+			if cache[i] == TELEGRAM_HEADER {
 				let length = cache[i + 1] as usize;
 				if length > APUD_MAX_LENGTH as usize {
 					whatever!("Invalid length: {}", length);

--- a/src/client/receive_handler.rs
+++ b/src/client/receive_handler.rs
@@ -134,7 +134,6 @@ impl<'a> ReceiveHandler<'a> {
 					);
 					i += length + 2;
 					next_start_i = i;
-					continue;
 				}
 			}else{
 				whatever!("Invalid starter byte: {:02x}{:02x}", cache[i], cache[i+1]);
@@ -145,7 +144,7 @@ impl<'a> ReceiveHandler<'a> {
 		} else if next_start_i > 0 {
 			*cache = cache.split_off(next_start_i);
 		}
-		return Ok(apdus);
+		Ok(apdus)
 	}
 
 	#[instrument(level = "debug", skip_all)]

--- a/src/client/receive_handler.rs
+++ b/src/client/receive_handler.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use lazy_static::lazy_static;
-use snafu::{FromString, ResultExt as _, whatever};
+use snafu::{OptionExt as _, ResultExt as _, whatever};
 use tokio::{
 	io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _, ReadHalf, WriteHalf},
 	select,
@@ -112,61 +112,30 @@ impl<'a> ReceiveHandler<'a> {
 		Apdu::from_bytes(&buffer[0..length + 2]).whatever_context("Error decoding APDU")
 	}
 
-	fn parse_apdus(cache: &mut Vec<u8>) -> (Vec<Apdu>, Option<Error>) {
-		if cache.len() < 2 {
-			return (Vec::new(), None);
+	/// Tries to parse an APDU from the reading buffer. If the buffer don't have
+	/// the full APDU bytes Ok(None) is returned
+	#[instrument(level = "debug")]
+	fn try_parse_apdu(reading_buffer: &mut VecDeque<u8>) -> Result<Option<Apdu>, Error> {
+		if reading_buffer.front().is_none_or(|&b| b != TELEGRAM_HEADER) {
+			whatever!("Invalid header");
 		}
-		let mut apdus = Vec::new();
-		let mut next_start_i = 0;
-		let mut i = 0;
-		let mut err = None;
-		while i < cache.len() - 1 {
-			if cache[i] == TELEGRAM_HEADER {
-				let length = cache[i + 1] as usize;
-				if length > APUD_MAX_LENGTH as usize {
-					err = Some(Error::without_source(format!("Invalid length: {length}")));
-					break;
-				}
-				if cache.len() < length + i + 2 {
-					break;
-				} else {
-					match Apdu::from_bytes(&cache[i..i + length + 2]) {
-						Ok(apdu) => {
-							apdus.push(apdu);
-							i += length + 2;
-							next_start_i = i;
-						}
-						Err(e) => {
-							err = Some(Error::with_source(
-								Box::new(e),
-								"Error decoding APDU".to_owned(),
-							));
-							break;
-						}
-					}
-				}
-			} else {
-				err = Some(Error::without_source(format!(
-					"Invalid starter byte: {:02x}{:02x}",
-					cache[i],
-					cache[i + 1]
-				)));
-				break;
-			}
+		let length = reading_buffer.get(1).whatever_context("Error getting length")?;
+		if *length > APUD_MAX_LENGTH {
+			whatever!("Invalid length: {length}");
 		}
-		if next_start_i >= cache.len() {
-			cache.clear();
-		} else if next_start_i > 0 {
-			*cache = cache.split_off(next_start_i);
+		if reading_buffer.len() >= (length + 2) as usize {
+			let apdu_bytes: Vec<u8> = reading_buffer.drain(0..(length + 2) as usize).collect();
+			Apdu::from_bytes(&apdu_bytes).map(Some)
+		} else {
+			Ok(None)
 		}
-		(apdus, err)
 	}
 
 	#[instrument(level = "debug", skip_all)]
 	pub async fn receive_task(mut self) -> Result<(), Error> {
 		self.t3.as_mut().reset(Instant::now() + self.config.protocol.t3);
 
-		let mut cache = Vec::new();
+		let mut reading_buffer: VecDeque<u8> = VecDeque::with_capacity(512);
 		let mut buffer = [0; 255];
 
 		loop {
@@ -176,34 +145,34 @@ impl<'a> ReceiveHandler<'a> {
 					if len == 0 {
 						whatever!("Connection closed");
 					}
-					cache.extend_from_slice(&buffer[0..len]);
-					let (apdus, err) = Self::parse_apdus(&mut cache);
-					if !apdus.is_empty() {
-						for apdu in apdus {
-							match apdu.frame {
-								Frame::I(i) => {
-									self.handle_receive_i_frame(&i)?;
-									let new_t2_instant = Instant::now() + self.config.protocol.t2;
-									if new_t2_instant < self.t2.deadline() {
-										self.t2.as_mut().reset(new_t2_instant);
-									}
-									self.callback.on_new_objects(i.asdu).await;
+					reading_buffer.extend(buffer[0..len].iter());
+					let mut reset_t3 = false;
+
+					while reading_buffer.len() > 2 && let Some(apdu) = Self::try_parse_apdu(&mut reading_buffer).whatever_context("Error parsing APDU")? {
+						match apdu.frame {
+							Frame::I(i) => {
+								self.handle_receive_i_frame(&i)?;
+								let new_t2_instant = Instant::now() + self.config.protocol.t2;
+								if new_t2_instant < self.t2.deadline() {
+									self.t2.as_mut().reset(new_t2_instant);
 								}
-								Frame::S(s) => {
-									self.handle_receive_s_frame(&s)?;
-								}
-								Frame::U(u) => {
-									let should_stop = self.handle_receive_u_frame(&u).await?;
-									if should_stop {
-										return Ok(());
-									}
+								self.callback.on_new_objects(i.asdu).await;
+							}
+							Frame::S(s) => {
+								self.handle_receive_s_frame(&s)?;
+							}
+							Frame::U(u) => {
+								let should_stop = self.handle_receive_u_frame(&u).await?;
+								if should_stop {
+									return Ok(());
 								}
 							}
 						}
-						self.t3.as_mut().reset(Instant::now() + self.config.protocol.t3);
+						reset_t3 = true;
 					}
-					if let Some(e) = err {
-						return Err(e);
+
+					if reset_t3{
+						self.t3.as_mut().reset(Instant::now() + self.config.protocol.t3);
 					}
 				}
 				Some(cmd) = self.rx.recv() => {


### PR DESCRIPTION
The function  `receive_apdu` is not cancel safety.
https://github.com/mzaniolo/iec104/blob/4093535fd12ce5f88185a71950e3e19452d6c811/src/client/receive_handler.rs#L95C1-L113C3
First, `read_exact` in line 109 is not cancel safety. Second, if the task is cancelled when `await` in line 110, the first 2 bytes read in line 100 will not be restored.
But `receive_apdu` is used in a `select!`, which could lead to a bug.
https://github.com/mzaniolo/iec104/blob/4093535fd12ce5f88185a71950e3e19452d6c811/src/client/receive_handler.rs#L123C1-L123C75
If other branches ( a command is received via channel, t2/t3 timeout, ... ) finished first, `receive_apdu` will be cancelled. If `receive_apdu` is currently at `await` point in line 110, the already read bytes will not restored and next `receive_apdu` will return a `Invalid starter byte` error because the header bytes are gone. When the network condition is not good enough and TCP stick packet / half packet occurs, header bytes may come in a packet while other bytes in another. The first 2 bytes are read in line 100, and task `receive_apdu` reached line 110, awaiting for other bytes. If a command ( e.g. sending ASDU ) is received via channel, the bug will occur.

To reproduce the bug, a bad network condition need to be simulated. This should be enough on Linux.
```bash
sudo tc qdisc add dev lo root netem rate 56kbit 0 1 0
```
**Important!** Remember to
```bash
sudo tc qdisc del dev lo root
```
after the test!
Server side: [test_server.py](https://github.com/user-attachments/files/23641517/test_server.py.txt)
Client side: [client.rs](https://github.com/user-attachments/files/23641520/client.rs.txt)
Log: [log_1.txt](https://github.com/user-attachments/files/23641527/log_1.txt)
Detailed log ( `receive_handler.rs` is modified to show more details ): [log_2.txt](https://github.com/user-attachments/files/23641545/log_2.txt) 
If bug not reproduced, adjust the delay in client side so that the controls will be sent just when interrogation results come back.

I think the best way to fix the unsafe cancel issue is to read the TCP connection at once, and analyse read data afterwards. The code is not as graceful as the original one, but it could fix the issue.

Log after fix: [log_fixed.txt](https://github.com/user-attachments/files/23641578/log_fixed.txt)