### PR TITLE
feat: Can opt-out TLS features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ keywords = [
 [features]
 chrono = ["dep:chrono"]
 time = ["dep:time"]
+native-tls = ["dep:tokio-native-tls"]
+default = ["native-tls"]
 
 [dependencies]
 async-trait = "0.1.88"
@@ -41,7 +43,7 @@ tokio = { version = "1.47.0", features = [
     "io-util",
 ] }
 
-tokio-native-tls = "0.3.1"
+tokio-native-tls = { version = "0.3.1", optional = true }
 tracing = "0.1.41"
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/src/client/connection_handler.rs
+++ b/src/client/connection_handler.rs
@@ -7,6 +7,7 @@ use tokio::{
 	net::TcpStream,
 	sync::mpsc,
 };
+#[cfg(feature = "native-tls")]
 use tokio_native_tls::{
 	TlsConnector,
 	native_tls::{Certificate, Identity},
@@ -162,7 +163,8 @@ impl<C: ClientCallback + Send + Sync + 'static> ConnectionHandler<C> {
 		.whatever_context("Connection timeout")?
 		.whatever_context("Error connecting")?;
 
-		Ok(if let Some(ref tls) = config.tls {
+		#[cfg(feature = "native-tls")]
+		return Ok(if let Some(ref tls) = config.tls {
 			let connector = Self::make_tls_connector(tls)?;
 			Connection::Tls(
 				connector
@@ -172,9 +174,18 @@ impl<C: ClientCallback + Send + Sync + 'static> ConnectionHandler<C> {
 			)
 		} else {
 			Connection::Tcp(stream)
-		})
+		});
+		#[cfg(not(feature = "native-tls"))]
+		if let Some(_) = config.tls {
+			snafu::whatever!(
+				"TLS features disabled! Recompile with \"native-tls\" feature on to enable them!"
+			);
+		} else {
+			Ok(Connection::Tcp(stream))
+		}
 	}
 
+	#[cfg(feature = "native-tls")]
 	#[instrument(level = "debug")]
 	fn make_tls_connector(tls: &TlsClientConfig) -> Result<TlsConnector, Error> {
 		let root_cert: Option<Certificate> = tls

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use tokio::{
 	io::{AsyncRead, AsyncWrite},
 	net::TcpStream,
 };
+#[cfg(feature = "native-tls")]
 use tokio_native_tls::TlsStream;
 
 use crate::apdu::{Frame, UFrame};
@@ -41,6 +42,7 @@ lazy_static! {
 #[derive(Debug)]
 enum Connection {
 	Tcp(TcpStream),
+	#[cfg(feature = "native-tls")]
 	Tls(TlsStream<TcpStream>),
 }
 
@@ -52,6 +54,7 @@ impl AsyncRead for Connection {
 	) -> std::task::Poll<std::io::Result<()>> {
 		match self.get_mut() {
 			Connection::Tcp(stream) => Pin::new(stream).poll_read(cx, buf),
+			#[cfg(feature = "native-tls")]
 			Connection::Tls(stream) => Pin::new(stream).poll_read(cx, buf),
 		}
 	}
@@ -65,6 +68,7 @@ impl AsyncWrite for Connection {
 	) -> std::task::Poll<Result<usize, std::io::Error>> {
 		match self.get_mut() {
 			Connection::Tcp(stream) => Pin::new(stream).poll_write(cx, buf),
+			#[cfg(feature = "native-tls")]
 			Connection::Tls(stream) => Pin::new(stream).poll_write(cx, buf),
 		}
 	}
@@ -75,6 +79,7 @@ impl AsyncWrite for Connection {
 	) -> std::task::Poll<Result<(), std::io::Error>> {
 		match self.get_mut() {
 			Connection::Tcp(stream) => Pin::new(stream).poll_flush(cx),
+			#[cfg(feature = "native-tls")]
 			Connection::Tls(stream) => Pin::new(stream).poll_flush(cx),
 		}
 	}
@@ -85,6 +90,7 @@ impl AsyncWrite for Connection {
 	) -> std::task::Poll<Result<(), std::io::Error>> {
 		match self.get_mut() {
 			Connection::Tcp(stream) => Pin::new(stream).poll_shutdown(cx),
+			#[cfg(feature = "native-tls")]
 			Connection::Tls(stream) => Pin::new(stream).poll_shutdown(cx),
 		}
 	}

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,6 +13,7 @@ use tokio::{
 	net::TcpListener,
 	sync::{mpsc, oneshot},
 };
+#[cfg(feature = "native-tls")]
 use tokio_native_tls::{TlsAcceptor, native_tls::Identity};
 
 /// Identifies a connection so it can be removed from the list when it
@@ -92,6 +93,7 @@ struct InnerServer<C: ServerCallback + Send + Sync + 'static> {
 	config: ServerConfig,
 	connections: HashMap<ConnectionId, ConnectionHandler>,
 	rx: mpsc::Receiver<ServerCommand>,
+	#[cfg(feature = "native-tls")]
 	acceptor: Option<TlsAcceptor>,
 	listener: TcpListener,
 }
@@ -162,26 +164,30 @@ impl<C: ServerCallback + Send + Sync + 'static> InnerServer<C> {
 		let listener = TcpListener::bind(&bind_addr)
 			.await
 			.with_whatever_context(|_| format!("Unable to bind to address '{bind_addr}'"))?;
-
-		let acceptor = config
-			.tls
-			.as_ref()
-			.map(|tls| {
-				let identity = Identity::from_pkcs8(
-					std::fs::read(tls.server_certificate.clone())
-						.whatever_context::<_, Error>("Failed to read server certificate")?
-						.as_slice(),
-					std::fs::read(tls.server_key.clone())
-						.whatever_context::<_, Error>("Failed to read server key")?
-						.as_slice(),
-				)
-				.whatever_context("Error creating server TLS identity")?;
-				tokio_native_tls::native_tls::TlsAcceptor::new(identity)
-					.map(TlsAcceptor::from)
-					.whatever_context("Error crating TLS acceptor")
-			})
-			.transpose()?;
-		Ok(Self { callback, config, connections: HashMap::new(), rx, acceptor, listener })
+		#[cfg(feature = "native-tls")]
+		{
+			let acceptor = config
+				.tls
+				.as_ref()
+				.map(|tls| {
+					let identity = Identity::from_pkcs8(
+						std::fs::read(tls.server_certificate.clone())
+							.whatever_context::<_, Error>("Failed to read server certificate")?
+							.as_slice(),
+						std::fs::read(tls.server_key.clone())
+							.whatever_context::<_, Error>("Failed to read server key")?
+							.as_slice(),
+					)
+					.whatever_context("Error creating server TLS identity")?;
+					tokio_native_tls::native_tls::TlsAcceptor::new(identity)
+						.map(TlsAcceptor::from)
+						.whatever_context("Error crating TLS acceptor")
+				})
+				.transpose()?;
+			Ok(Self { callback, config, connections: HashMap::new(), rx, acceptor, listener })
+		}
+		#[cfg(not(feature = "native-tls"))]
+		Ok(Self { callback, config, connections: HashMap::new(), rx, listener })
 	}
 
 	fn listen_local_addr(&self) -> std::io::Result<SocketAddr> {
@@ -197,6 +203,7 @@ impl<C: ServerCallback + Send + Sync + 'static> InnerServer<C> {
 				accept_result = self.listener.accept() => {
 					let (socket, address) =
 						accept_result.whatever_context("Error accepting a new connection")?;
+					#[cfg(feature = "native-tls")]
 					let connection = if let Some(ref acceptor) = self.acceptor {
 						Connection::Tls(
 							acceptor
@@ -207,6 +214,8 @@ impl<C: ServerCallback + Send + Sync + 'static> InnerServer<C> {
 					} else {
 						Connection::Tcp(socket)
 					};
+					#[cfg(not(feature = "native-tls"))]
+					let connection = Connection::Tcp(socket);
 					// TODO: Do we want to accept or decline the connection based on the callback response?
 					self.callback.on_new_connection(address).await;
 


### PR DESCRIPTION
Use `default-features = false` to compile the library without TLS features on legacy Linux systems, where system OpenSSL version is too low to compile `tokio-native-tls`.