### PR TITLE
fix: Add check for max length in GI response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "iec104"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "atomic_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iec104"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["Matheus Zaniolo <mgzaniolo@gmail.com>"]
 description = "A rust implementation of the IEC-60870-5-104 protocol."

--- a/src/apdu.rs
+++ b/src/apdu.rs
@@ -8,6 +8,12 @@ use crate::{
 
 pub(crate) const TELEGRAM_HEADER: u8 = 0x68;
 pub(crate) const APUD_MAX_LENGTH: u8 = 253;
+/// Start byte and length octet preceding the APDU payload.
+pub(crate) const APDU_HEADER_SIZE: usize = 2;
+/// Control field octets at the start of every APDU payload.
+pub(crate) const CONTROL_FIELDS_SIZE: usize = 4;
+/// Maximum on-wire APDU frame size (header + max payload).
+pub(crate) const MAX_APDU_FRAME_SIZE: usize = APDU_HEADER_SIZE + APUD_MAX_LENGTH as usize;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Apdu {
@@ -19,7 +25,7 @@ impl Apdu {
 	#[instrument]
 	pub fn from_bytes(data: &[u8]) -> Result<Self, Error> {
 		// Check if the data is long enough to contain the APDU header
-		if data.len() < 6 {
+		if data.len() < APDU_HEADER_SIZE + CONTROL_FIELDS_SIZE {
 			return error::ApduTooShort.fail();
 		}
 		if data[0] != TELEGRAM_HEADER {
@@ -32,20 +38,21 @@ impl Apdu {
 			return error::InvalidLength.fail();
 		}
 
-		let control_fields = data[2..6].try_into().context(SizedSlice)?;
-		let frame = if length == 4_u8 {
+		let asdu_start = APDU_HEADER_SIZE + CONTROL_FIELDS_SIZE;
+		let control_fields = data[APDU_HEADER_SIZE..asdu_start].try_into().context(SizedSlice)?;
+		let frame = if usize::from(length) == CONTROL_FIELDS_SIZE {
 			Frame::from_control_fields(control_fields)
 		} else {
-			Frame::from_asdu(control_fields, data.get(6..).context(NotEnoughBytes)?)
+			Frame::from_asdu(control_fields, data.get(asdu_start..).context(NotEnoughBytes)?)
 		}?;
 
 		Ok(Self { length, frame })
 	}
 
 	pub fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-		// The total length of the APDU is the length of the frame plus 2 bytes, one for
-		// the header and one for the length
-		let mut bytes = Vec::with_capacity(self.length as usize + 2);
+		// The total length of the APDU is the length of the frame plus the start
+		// byte and the length octet
+		let mut bytes = Vec::with_capacity(self.length as usize + APDU_HEADER_SIZE);
 		bytes.push(TELEGRAM_HEADER);
 		bytes.push(self.length);
 		self.frame.to_bytes(&mut bytes)?;
@@ -61,7 +68,7 @@ pub enum Frame {
 }
 
 impl Frame {
-	fn from_control_fields(control_fields: [u8; 4]) -> Result<Self, Error> {
+	fn from_control_fields(control_fields: [u8; CONTROL_FIELDS_SIZE]) -> Result<Self, Error> {
 		match control_fields[0] & 0b0000_0011 {
 			0b0000_0011 => Ok(Frame::U(UFrame::from_control_fields(control_fields)?)),
 			0b0000_0001 => Ok(Frame::S(SFrame::from_control_fields(control_fields)?)),
@@ -69,7 +76,7 @@ impl Frame {
 		}
 	}
 
-	fn from_asdu(control_fields: [u8; 4], asdu: &[u8]) -> Result<Self, Error> {
+	fn from_asdu(control_fields: [u8; CONTROL_FIELDS_SIZE], asdu: &[u8]) -> Result<Self, Error> {
 		Ok(Frame::I(IFrame::from_asdu(control_fields, asdu)?))
 	}
 
@@ -89,7 +96,7 @@ impl Frame {
 		// APDU payload must not exceed 253 bytes. Pre-fix `as u8`
 		// silently truncated, so an oversize ASDU went on the wire with
 		// a wrapped length field.
-		let payload_len = buffer.len() - 2;
+		let payload_len = buffer.len() - APDU_HEADER_SIZE;
 		if payload_len > APUD_MAX_LENGTH as usize {
 			return error::InvalidLength.fail();
 		}
@@ -110,7 +117,7 @@ pub struct IFrame {
 
 impl IFrame {
 	#[instrument]
-	fn from_asdu(control_fields: [u8; 4], asdu: &[u8]) -> Result<Self, Error> {
+	fn from_asdu(control_fields: [u8; CONTROL_FIELDS_SIZE], asdu: &[u8]) -> Result<Self, Error> {
 		if (control_fields[0] & 0b0000_0001) != 0 || (control_fields[2] & 0b0000_0001) != 0 {
 			return error::InvalidIFrameControlFields.fail();
 		}
@@ -119,7 +126,7 @@ impl IFrame {
 				control_fields[0..2].try_into().context(SizedSlice)?,
 			) >> 1,
 			receive_sequence_number: u16::from_le_bytes(
-				control_fields[2..4].try_into().context(SizedSlice)?,
+				control_fields[2..CONTROL_FIELDS_SIZE].try_into().context(SizedSlice)?,
 			) >> 1,
 			asdu: Asdu::parse(asdu).context(InvalidAsdu)?,
 		})
@@ -150,13 +157,13 @@ pub struct SFrame {
 
 impl SFrame {
 	#[instrument]
-	fn from_control_fields(control_fields: [u8; 4]) -> Result<Self, Error> {
+	fn from_control_fields(control_fields: [u8; CONTROL_FIELDS_SIZE]) -> Result<Self, Error> {
 		if control_fields[0] != 0b0000_0001 || control_fields[1] != 0b0000_0000 {
 			return error::InvalidSFrameControlFields.fail();
 		}
 		Ok(Self {
 			receive_sequence_number: u16::from_le_bytes(
-				control_fields[2..4].try_into().context(SizedSlice)?,
+				control_fields[2..CONTROL_FIELDS_SIZE].try_into().context(SizedSlice)?,
 			) >> 1,
 		})
 	}
@@ -198,7 +205,7 @@ pub struct UFrame {
 
 impl UFrame {
 	#[instrument]
-	fn from_control_fields(control_fields: [u8; 4]) -> Result<Self, Error> {
+	fn from_control_fields(control_fields: [u8; CONTROL_FIELDS_SIZE]) -> Result<Self, Error> {
 		if control_fields[1] != 0 || control_fields[2] != 0 || control_fields[3] != 0 {
 			return error::InvalidUFrameControlFields.fail();
 		}
@@ -258,7 +265,7 @@ mod tests {
 	fn test_s_frame() -> Result<(), Error> {
 		let bytes = [0x68, 0x04, 0x01, 0x00, 0x7E, 0x14];
 		let apdu = Apdu::from_bytes(&bytes)?;
-		assert_eq!(apdu.length, 4);
+		assert_eq!(apdu.length, CONTROL_FIELDS_SIZE as u8);
 
 		let Frame::S(s_frame) = &apdu.frame else { panic!("Frame was expected to be an S-frame") };
 		assert_eq!(s_frame.receive_sequence_number, 2623);
@@ -397,7 +404,7 @@ mod tests {
 	fn test_u_frame() -> Result<(), Error> {
 		let bytes = [0x68, 0x04, 0x01, 0x00, 0x7E, 0x14];
 		let apdu = Apdu::from_bytes(&bytes)?;
-		assert_eq!(apdu.length, 4);
+		assert_eq!(apdu.length, CONTROL_FIELDS_SIZE as u8);
 
 		Ok(())
 	}
@@ -405,16 +412,21 @@ mod tests {
 	#[test]
 	fn to_apdu_bytes_rejects_oversize_payload() {
 		use crate::{
-			asdu::Asdu,
-			types::{GenericObject, MMeNc1},
+			asdu::{ASDU_HEADER_SIZE, Asdu},
+			types::{ADDRESS_SIZE, GenericObject, MMeNc1},
 		};
 
-		// Build an I-frame whose ASDU exceeds the 253-byte payload
-		// limit. Each `M_ME_NC_1` is 5 bytes of payload + 3 bytes of IOA,
-		// non-sequence — 32 objects = 256 bytes of information objects,
-		// plus the 6-byte ASDU header = 262 bytes, well over 253.
-		let objects: Vec<GenericObject<MMeNc1>> =
-			(0_u32..32).map(|i| GenericObject { address: i, object: MMeNc1::default() }).collect();
+		// 32 non-sequence M_ME_NC_1 objects exceed APUD_MAX_LENGTH:
+		// ASDU_HEADER_SIZE + 32 * (ADDRESS_SIZE + TypeId::M_ME_NC_1.size()).
+		let object_count = 32_usize;
+		let asdu_body = ASDU_HEADER_SIZE + object_count * (ADDRESS_SIZE + TypeId::M_ME_NC_1.size());
+		assert!(
+			CONTROL_FIELDS_SIZE + asdu_body > APUD_MAX_LENGTH as usize,
+			"fixture must exceed APDU max length"
+		);
+		let objects: Vec<GenericObject<MMeNc1>> = (0_u32..object_count as u32)
+			.map(|i| GenericObject { address: i, object: MMeNc1::default() })
+			.collect();
 		let asdu = Asdu {
 			type_id: TypeId::M_ME_NC_1,
 			cot: Cot::SpontaneousData,

--- a/src/asdu.rs
+++ b/src/asdu.rs
@@ -4,9 +4,14 @@ use tracing::instrument;
 use crate::{
 	cot::{Cot, CotError},
 	error::SpanTraceWrapper,
-	types::{InformationObjects, ParseError},
+	types::{ADDRESS_SIZE, InformationObjects, ParseError},
 	types_id::TypeId,
 };
+
+/// ASDU header: type id, VSQ, COT (2), originator address, common address (2).
+pub(crate) const ASDU_HEADER_SIZE: usize = 6;
+/// Maximum number of information objects per ASDU (7-bit VSQ count field).
+pub(crate) const MAX_OBJECTS_PER_ASDU: usize = 127;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Asdu {
@@ -42,21 +47,23 @@ impl Asdu {
 			*bytes.get(5).context(NotEnoughBytes)?,
 		]);
 
-		let remaining_bytes = bytes.get(6..).context(NotEnoughBytes)?;
+		let remaining_bytes = bytes.get(ASDU_HEADER_SIZE..).context(NotEnoughBytes)?;
 		if type_id.is_standard() {
 			let object_size = type_id.size();
 			let remaining_bytes_size = remaining_bytes.len();
 
 			// Validate the wire layout in one place using checked arithmetic.
-			// A sequence carries one 3-byte IOA followed by `num_objs` payloads
+			// A sequence carries one ADDRESS_SIZE IOA followed by `num_objs` payloads
 			// of `object_size` bytes each; a non-sequence is `num_objs` repeats
 			// of `(IOA + payload)`. Both pre-fix branches did
-			// `remaining_bytes_size - 3` which underflows on a malformed
+			// `remaining_bytes_size - ADDRESS_SIZE` which underflows on a malformed
 			// short ASDU.
 			let expected = if sequence {
-				(num_objs as usize).checked_mul(object_size).and_then(|n| n.checked_add(3))
+				(num_objs as usize)
+					.checked_mul(object_size)
+					.and_then(|n| n.checked_add(ADDRESS_SIZE))
 			} else {
-				(num_objs as usize).checked_mul(object_size.saturating_add(3))
+				(num_objs as usize).checked_mul(object_size.saturating_add(ADDRESS_SIZE))
 			};
 			if expected != Some(remaining_bytes_size) {
 				return NumberOfObjects {
@@ -86,7 +93,7 @@ impl Asdu {
 	pub fn to_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), AsduError> {
 		buffer.push(self.type_id as u8);
 		let num_objs = self.information_objects.len();
-		if num_objs > 127 {
+		if num_objs > MAX_OBJECTS_PER_ASDU {
 			return TooManyObjects { num_objs }.fail();
 		}
 		let mut byte: u8 = num_objs as u8;
@@ -142,7 +149,10 @@ pub enum AsduError {
 		#[snafu(implicit)]
 		context: Box<SpanTraceWrapper>,
 	},
-	#[snafu(display("Too many objects. Max number of objects is 127, got {num_objs} objects."))]
+	#[snafu(display(
+		"Too many objects. Max number of objects is {}, got {num_objs} objects.",
+		MAX_OBJECTS_PER_ASDU
+	))]
 	TooManyObjects {
 		num_objs: usize,
 		#[snafu(implicit)]
@@ -163,25 +173,25 @@ mod tests {
 	/// Header common to all the malformed-tail tests below: type
 	/// `M_SP_NA_1` (size = 1 byte), 1 object, COT = SpontaneousData, OA = 0,
 	/// CA = 1.
-	const HEADER: [u8; 6] = [0x01, 0x01, 0x03, 0x00, 0x01, 0x00];
+	const HEADER: [u8; ASDU_HEADER_SIZE] = [0x01, 0x01, 0x03, 0x00, 0x01, 0x00];
 
 	#[test]
 	fn parse_sequence_with_short_tail_does_not_panic() {
 		// sequence=true means SQ bit set on byte 1 (0x80 | 0x01 = 0x81).
-		// A sequence ASDU needs at least 3 bytes (IOA) + N*size — give
-		// it only 2 bytes so the pre-fix `remaining_bytes_size - 3`
+		// A sequence ASDU needs at least ADDRESS_SIZE (IOA) + N*size — give
+		// it only 2 bytes so the pre-fix `remaining_bytes_size - ADDRESS_SIZE`
 		// would underflow.
 		let mut bytes = HEADER;
 		bytes[1] = 0x81;
 		let mut input = bytes.to_vec();
-		input.extend_from_slice(&[0x00, 0x00]); // 2-byte tail (< 3)
+		input.extend_from_slice(&[0x00, 0x00]); // 2-byte tail (< ADDRESS_SIZE)
 		let err = Asdu::parse(&input).expect_err("must reject short sequence ASDU");
 		assert!(matches!(err, AsduError::NumberOfObjects { .. }), "got: {err:?}");
 	}
 
 	#[test]
 	fn parse_sequence_with_zero_tail_does_not_panic() {
-		// Even tighter: zero tail bytes after the 6-byte ASDU header.
+		// Even tighter: zero tail bytes after the ASDU header.
 		let mut bytes = HEADER;
 		bytes[1] = 0x81;
 		let err = Asdu::parse(&bytes).expect_err("must reject empty sequence tail");
@@ -190,8 +200,8 @@ mod tests {
 
 	#[test]
 	fn parse_non_sequence_with_short_tail_rejected() {
-		// Non-sequence M_SP_NA_1 with num_objs=1 needs 4 bytes (3 IOA + 1
-		// payload). Provide only 3 bytes (just the IOA).
+		// Non-sequence M_SP_NA_1 with num_objs=1 needs ADDRESS_SIZE + 1
+		// payload bytes. Provide only ADDRESS_SIZE bytes (just the IOA).
 		let mut input = HEADER.to_vec();
 		input.extend_from_slice(&[0x10, 0x00, 0x00]);
 		let err = Asdu::parse(&input).expect_err("must reject short non-sequence ASDU");

--- a/src/client/connection_handler.rs
+++ b/src/client/connection_handler.rs
@@ -13,7 +13,7 @@ use tracing::instrument;
 use crate::tls::TlsClientConnector;
 use crate::{
 	START_DT_ACT_FRAME,
-	apdu::Frame,
+	apdu::{Frame, MAX_APDU_FRAME_SIZE},
 	client::{ClientCallback, Connection, InnerClientCallback},
 	config::ClientConfig,
 	error::Error,
@@ -181,7 +181,7 @@ impl<C: ClientCallback + Send + Sync + 'static> ConnectionHandler<C> {
 
 	#[instrument(level = "debug", skip_all)]
 	pub async fn send_start_dt(&mut self) -> Result<(), Error> {
-		let mut buffer = [0; 255];
+		let mut buffer = [0; MAX_APDU_FRAME_SIZE];
 		send_frame(&mut self.write_connection, &START_DT_ACT_FRAME)
 			.await
 			.whatever_context("Error sending startDT activation")?;

--- a/src/receive_handler.rs
+++ b/src/receive_handler.rs
@@ -20,7 +20,10 @@ use tracing::instrument;
 
 use crate::{
 	Connection, STOP_DT_ACT_FRAME, STOP_DT_CON_FRAME, TEST_FR_ACT_FRAME, TEST_FR_CON_FRAME,
-	apdu::{APUD_MAX_LENGTH, Apdu, Frame, IFrame, SFrame, TELEGRAM_HEADER, UFrame},
+	apdu::{
+		APDU_HEADER_SIZE, APUD_MAX_LENGTH, Apdu, Frame, IFrame, MAX_APDU_FRAME_SIZE, SFrame,
+		TELEGRAM_HEADER, UFrame,
+	},
 	asdu::Asdu,
 	config::ProtocolConfig,
 	error::Error,
@@ -107,9 +110,12 @@ pub(crate) async fn send_frame<W: AsyncWrite + Unpin>(
 #[instrument(level = "debug", skip_all)]
 pub(crate) async fn receive_apdu<R: AsyncRead + Unpin>(
 	connection: &mut R,
-	buffer: &mut [u8; 255],
+	buffer: &mut [u8; MAX_APDU_FRAME_SIZE],
 ) -> Result<Apdu, Error> {
-	connection.read_exact(&mut buffer[0..2]).await.whatever_context("Error receiving data")?;
+	connection
+		.read_exact(&mut buffer[0..APDU_HEADER_SIZE])
+		.await
+		.whatever_context("Error receiving data")?;
 	if buffer[0] != TELEGRAM_HEADER {
 		whatever!("Invalid starter byte: {:02x}{:02x}", buffer[0], buffer[1]);
 	}
@@ -117,11 +123,12 @@ pub(crate) async fn receive_apdu<R: AsyncRead + Unpin>(
 	if length > APUD_MAX_LENGTH as usize {
 		whatever!("Invalid length: {}", length);
 	}
+	let frame_end = APDU_HEADER_SIZE + length;
 	connection
-		.read_exact(&mut buffer[2..length + 2])
+		.read_exact(&mut buffer[APDU_HEADER_SIZE..frame_end])
 		.await
 		.whatever_context("Error receiving data")?;
-	Apdu::from_bytes(&buffer[0..length + 2]).whatever_context("Error decoding APDU")
+	Apdu::from_bytes(&buffer[0..frame_end]).whatever_context("Error decoding APDU")
 }
 
 /// Reason enqueueing an ASDU was rejected by the receive-handler task.
@@ -210,8 +217,9 @@ impl<'a, C: ReceiveHandlerCallback> ReceiveHandler<'a, C> {
 		if *length > APUD_MAX_LENGTH {
 			whatever!("Invalid length: {length}");
 		}
-		if reading_buffer.len() >= (length + 2) as usize {
-			let apdu_bytes: Vec<u8> = reading_buffer.drain(0..(length + 2) as usize).collect();
+		if reading_buffer.len() >= APDU_HEADER_SIZE + usize::from(*length) {
+			let apdu_bytes: Vec<u8> =
+				reading_buffer.drain(0..APDU_HEADER_SIZE + usize::from(*length)).collect();
 			Apdu::from_bytes(&apdu_bytes).map(Some)
 		} else {
 			Ok(None)
@@ -223,7 +231,7 @@ impl<'a, C: ReceiveHandlerCallback> ReceiveHandler<'a, C> {
 		self.t3.as_mut().reset(Instant::now() + self.config.t3);
 
 		let mut reading_buffer: VecDeque<u8> = VecDeque::with_capacity(512);
-		let mut buffer = [0; 255];
+		let mut buffer = [0; MAX_APDU_FRAME_SIZE];
 
 		loop {
 			select! {
@@ -235,7 +243,7 @@ impl<'a, C: ReceiveHandlerCallback> ReceiveHandler<'a, C> {
 					reading_buffer.extend(buffer[0..len].iter());
 					let mut reset_t3 = false;
 
-					while reading_buffer.len() > 2 && let Some(apdu) = Self::try_parse_apdu(&mut reading_buffer).whatever_context("Error parsing APDU")? {
+					while reading_buffer.len() > APDU_HEADER_SIZE && let Some(apdu) = Self::try_parse_apdu(&mut reading_buffer).whatever_context("Error parsing APDU")? {
 						match apdu.frame {
 							Frame::I(i) => {
 								self.handle_receive_i_frame(&i)?;

--- a/src/rtu_server/output.rs
+++ b/src/rtu_server/output.rs
@@ -5,22 +5,31 @@ use std::collections::HashMap;
 
 use super::model::{PointAddress, PointValue};
 use crate::{
-	asdu::Asdu,
+	apdu::{APUD_MAX_LENGTH, CONTROL_FIELDS_SIZE},
+	asdu::{ASDU_HEADER_SIZE, Asdu, MAX_OBJECTS_PER_ASDU},
 	cot::Cot,
 	types::{
-		FromBytes, GenericObject, InformationObjects, MBoNa1, MBoTb1, MDpNa1, MDpTa1, MDpTb1,
-		MEiNa1, MEpTa1, MEpTb1, MEpTc1, MEpTd1, MEpTe1, MEpTf1, MItNa1, MItTb1, MMeNa1, MMeNb1,
-		MMeNc1, MMeNd1, MMeTa1, MMeTb1, MMeTc1, MMeTd1, MMeTe1, MMeTf1, MPsNa1, MSpNa1, MSpTa1,
-		MSpTb1, MStNa1, MStTa1, MStTb1, ToBytes,
+		ADDRESS_SIZE, FromBytes, GenericObject, InformationObjects, MBoNa1, MBoTb1, MDpNa1, MDpTa1,
+		MDpTb1, MEiNa1, MEpTa1, MEpTb1, MEpTc1, MEpTd1, MEpTe1, MEpTf1, MItNa1, MItTb1, MMeNa1,
+		MMeNb1, MMeNc1, MMeNd1, MMeTa1, MMeTb1, MMeTc1, MMeTd1, MMeTe1, MMeTf1, MPsNa1, MSpNa1,
+		MSpTa1, MSpTb1, MStNa1, MStTa1, MStTb1, ToBytes,
 		commands::{Qoi, Rqt},
 	},
 	types_id::TypeId,
 };
 
-/// Maximum number of information objects per ASDU (7-bit count field).
-pub(super) const MAX_OBJECTS_PER_ASDU: usize = 127;
 /// Global common address for global interrogation.
 const GLOBAL_COMMON_ADDRESS: u16 = 0xFFFF;
+
+/// Max objects that fit in one non-sequence ASDU under the APDU length cap.
+#[must_use]
+fn max_objects_fitting_apdu(type_id: TypeId) -> usize {
+	let per_object = ADDRESS_SIZE + type_id.size();
+	let available = APUD_MAX_LENGTH as usize - CONTROL_FIELDS_SIZE - ASDU_HEADER_SIZE;
+	// Standard monitoring types always fit at least one object; guard `chunks(0)`.
+	let by_bytes = (available / per_object).max(1);
+	by_bytes.min(MAX_OBJECTS_PER_ASDU)
+}
 
 /// [`Cot`] for monitoring ASDUs answering `C_IC_NA_1` with this QOI (global or
 /// group 1–16). [`None`] for [`Qoi::Unused`], [`Qoi::Other`], etc.
@@ -90,7 +99,7 @@ fn sort_and_push_interrogation_chunks<T>(
 	InformationObjects: From<Vec<GenericObject<T>>>,
 {
 	objs.sort_by_key(|(ioa, _)| *ioa);
-	for chunk in objs.chunks(MAX_OBJECTS_PER_ASDU) {
+	for chunk in objs.chunks(max_objects_fitting_apdu(type_id)) {
 		let chunk_objs: Vec<_> = chunk
 			.iter()
 			.map(|(ioa, m)| GenericObject { address: *ioa, object: m.clone() })
@@ -371,11 +380,20 @@ pub(super) fn counter_interrogation_data(
 mod interrogation_qoi_tests {
 	use std::collections::HashMap;
 
-	use super::{interrogation_data_asdus, interrogation_data_cot};
+	use super::{interrogation_data_asdus, interrogation_data_cot, max_objects_fitting_apdu};
 	use crate::{
 		rtu_server::model::{PointAddress, PointValue},
 		types::{MMeNa1, commands::Qoi, quality_descriptors::Qds},
+		types_id::TypeId,
 	};
+
+	#[test]
+	fn max_objects_fitting_apdu_known_sizes() {
+		assert_eq!(max_objects_fitting_apdu(TypeId::M_ME_NA_1), 40);
+		assert_eq!(max_objects_fitting_apdu(TypeId::M_ME_NC_1), 30);
+		assert_eq!(max_objects_fitting_apdu(TypeId::M_SP_NA_1), 60);
+		assert_eq!(max_objects_fitting_apdu(TypeId::M_IT_NA_1), 30);
+	}
 
 	#[test]
 	fn cot_tracks_qoi() {
@@ -428,6 +446,42 @@ mod interrogation_qoi_tests {
 		let groups = HashMap::new();
 		assert!(interrogation_data_asdus(ca, &model, Qoi::Unused, &groups).is_empty());
 		assert!(interrogation_data_asdus(ca, &model, Qoi::Other(19), &groups).is_empty());
+	}
+
+	/// 50 non-sequence `M_ME_NA_1` objects exceed the 253-byte APDU payload
+	/// limit (~40 objects max). GI packing must split into multiple ASDUs so
+	/// each encodes successfully.
+	#[test]
+	fn interrogation_asdus_fit_within_apdu_max_length() {
+		use crate::apdu::{Frame, IFrame};
+
+		let ca = 1_u16;
+		let point_count = 50_u32;
+		let mut model = HashMap::new();
+		for ioa in 1..=point_count {
+			model.insert(
+				PointAddress::new(ca, ioa),
+				PointValue::MMeNa1(MMeNa1 { nva: ioa as i16, qds: Qds::default() }),
+			);
+		}
+		let groups = HashMap::new();
+
+		let asdus = interrogation_data_asdus(ca, &model, Qoi::Global, &groups);
+		let total_objects: usize = asdus.iter().map(|a| a.information_objects.len()).sum();
+		assert_eq!(total_objects, point_count as usize);
+		assert!(
+			asdus.len() > 1,
+			"50 M_ME_NA_1 points must be split across multiple ASDUs to fit APDU max length"
+		);
+
+		for asdu in &asdus {
+			let frame = Frame::I(IFrame {
+				send_sequence_number: 0,
+				receive_sequence_number: 0,
+				asdu: asdu.clone(),
+			});
+			frame.to_apdu_bytes().expect("each GI data ASDU must encode within APUD_MAX_LENGTH");
+		}
 	}
 }
 

--- a/src/server/connection_handler.rs
+++ b/src/server/connection_handler.rs
@@ -13,7 +13,7 @@ use tokio::{
 use super::ConnectionId;
 use crate::{
 	Connection, START_DT_CON_FRAME, TEST_FR_CON_FRAME,
-	apdu::Frame,
+	apdu::{Frame, MAX_APDU_FRAME_SIZE},
 	asdu::Asdu,
 	config::ServerConfig,
 	error::Error,
@@ -102,7 +102,7 @@ impl ConnectionHandler {
 
 impl<C: ServerCallback + Send + Sync + 'static> InnerConnectionHandler<C> {
 	pub async fn start(mut self) -> Result<(), Error> {
-		let mut buffer = [0; 255];
+		let mut buffer = [0; MAX_APDU_FRAME_SIZE];
 		let out_buffer_full = Arc::new(AtomicBool::new(false));
 
 		loop {

--- a/src/types.rs
+++ b/src/types.rs
@@ -89,4 +89,5 @@ pub struct GenericObject<T: FromBytes + ToBytes + Default> {
 
 mod information_objects;
 
+pub(crate) use information_objects::ADDRESS_SIZE;
 pub use information_objects::InformationObjects;

--- a/src/types/information_objects.rs
+++ b/src/types/information_objects.rs
@@ -17,7 +17,8 @@ use super::{
 };
 use crate::types_id::TypeId;
 
-const ADDRESS_SIZE: usize = 3;
+/// Information object address (IOA) size on the wire.
+pub(crate) const ADDRESS_SIZE: usize = 3;
 
 macro_rules! define_information_objects {
 	(
@@ -41,11 +42,11 @@ macro_rules! define_information_objects {
 			) -> Result<Vec<GenericObject<T>>, ParseError> {
 				if !type_id.is_standard() {
 					tracing::trace!("Building RAW information objects. Bytes: {:?}", bytes);
-					if bytes.len() < 3 {
+					if bytes.len() < ADDRESS_SIZE {
 						return NotEnoughBytes.fail();
 					}
 					let address = u32::from_be_bytes([0, bytes[2], bytes[1], bytes[0]]);
-					let object = T::from_bytes(&bytes[3..])?;
+					let object = T::from_bytes(&bytes[ADDRESS_SIZE..])?;
 					return Ok(vec![GenericObject { address, object }]);
 				}
 				let object_size = type_id.size();
@@ -248,9 +249,9 @@ mod tests {
 	#[test]
 	fn from_bytes_non_sequence_rejects_short_trailing_chunk() {
 		// `from_bytes` is `pub` and may be called outside `Asdu::parse`'s
-		// pre-validation. Passing a M_SP_NA_1 (1-byte payload, IOA = 3
-		// bytes → chunk size 4) tail with 5 bytes used to surface a
-		// panic via `chunks` indexing the short trailing chunk.
+		// pre-validation. Passing a M_SP_NA_1 (1-byte payload + ADDRESS_SIZE
+		// IOA → chunk size ADDRESS_SIZE + 1) tail with 5 bytes used to
+		// surface a panic via `chunks` indexing the short trailing chunk.
 		let bytes = [0x10, 0x00, 0x00, 0x00, 0xFF];
 		let err = InformationObjects::from_bytes(TypeId::M_SP_NA_1, false, 1, &bytes)
 			.expect_err("must reject malformed tail");


### PR DESCRIPTION
In the server response for a GI the max number of objects that could fit was only checked based on the biggest number we could have in the count field without considering the max max length of an APDU. This PR fix this by adding both checks.
I also took the opportunity to remove some magic numbers that I had in the code.

Closes: #20 